### PR TITLE
Upgrade node.js to 16.x

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -56,7 +56,7 @@ resource "aws_lambda_function" "this" {
 
   description = "Basic HTTP authentication module/function"
   role        = aws_iam_role.this.arn
-  runtime     = "nodejs10.x"
+  runtime     = "nodejs16.x"
 
   filename         = "${path.module}/src-lamda.zip"
   source_code_hash = filebase64sha256("${path.module}/src-lamda/main.js")


### PR DESCRIPTION
Starting January 1, 2022, AWS SDK For JavaScript (v3) will no longer support Node.js 10.x which was EOL on April 30, 2021.